### PR TITLE
Ported from Qt 4.8 to Qt 5.2!

### DIFF
--- a/src/QtWeb.pro
+++ b/src/QtWeb.pro
@@ -1,7 +1,7 @@
 TEMPLATE = app
 TARGET = QtWeb
-QT += network xml webkit
-CONFIG += static
+QT += network xml webkit widgets webkitwidgets http ftp
+#CONFIG += static
 QTPLUGIN += qcncodecs qjpcodecs qkrcodecs qtwcodecs qico 
 DEFINES += QT_NO_UITOOLS
 

--- a/src/autocomplete.cpp
+++ b/src/autocomplete.cpp
@@ -19,6 +19,7 @@
 
 #include "autocomplete.h"
 #include <QUrl>
+#include <QUrlQuery>
 #include <QMap>
 #include <QDomElement>
 #include <QSettings>
@@ -66,7 +67,7 @@ QString DecryptPassword(QString str)
     {
         for (int j = 0; j < 4 ; j++)
         {
-            char c = str[i + j].toAscii();
+            char c = str[i + j].toLatin1();//.toLatin1();
             int v = 0;
             if (c >= '0' && c <= '9')
                 v = c - '0';
@@ -130,7 +131,8 @@ bool AutoComplete::evaluate(QUrl form_url)
     QMap<QString, QString> data_map;
     QUrl url( "?" + m_data );
     QPair<QString, QString> item;
-    foreach(item, url.queryItems())
+    QUrlQuery urlQuery(url);
+    foreach(item, urlQuery.queryItems())
     {
         QString name = item.first;
         QString value = item.second;
@@ -238,7 +240,8 @@ next_form:
             settings.setValue( "form_username_control", user_name);
 
             bool bFirst = true;
-            foreach(item, url.queryItems())
+
+            foreach(item, urlQuery.queryItems())
             {
                 QString name = item.first;
                 QString lower_name = name.toLower();

--- a/src/bookmarks.cpp
+++ b/src/bookmarks.cpp
@@ -51,11 +51,12 @@
 #include <QtCore/QMimeData>
 #include <QtCore/QSettings>
 #include <QtGui/QDragEnterEvent>
-#include <QtGui/QFileDialog>
-#include <QtGui/QHeaderView>
+#include <QDrag>
+#include <QtWidgets/QFileDialog>
+#include <QtWidgets/QHeaderView>
 #include <QtGui/QIcon>
-#include <QtGui/QMessageBox>
-#include <QtGui/QToolButton>
+#include <QtWidgets/QMessageBox>
+#include <QtWidgets/QToolButton>
 #include <QInputDialog>
 
 #include <QtWebKit/QWebSettings>
@@ -1373,7 +1374,7 @@ void BookmarkToolButton::mouseMoveEvent(QMouseEvent *event)
      lst << m_url;
      mimeData->setUrls( lst );
      mimeData->setText( text() );
-     mimeData->setProperty( "move", QVariant(TRUE));
+     mimeData->setProperty( "move", QVariant(true));
      drag->setMimeData(mimeData);
 
     Qt::DropAction dropAction = drag->exec(Qt::CopyAction | Qt::MoveAction);

--- a/src/bookmarks.h
+++ b/src/bookmarks.h
@@ -27,7 +27,7 @@
 #include <QtCore/QAbstractItemModel>
 #include <qtoolbutton.h>
 
-#include <QtGui/QUndoCommand>
+#include <QtWidgets/QUndoCommand>
 
 /*!
     Bookmark manager, owner of the bookmarks, loads, saves and basic tasks
@@ -216,7 +216,7 @@ private:
     Proxy model that filters out the bookmarks so only the folders
     are left behind.  Used in the add bookmark dialog combobox.
  */
-#include <QtGui/QSortFilterProxyModel>
+#include <QSortFilterProxyModel>
 class AddBookmarkProxyModel : public QSortFilterProxyModel
 {
     Q_OBJECT
@@ -278,7 +278,7 @@ private:
     TreeProxyModel *m_proxyModel;
 };
 
-#include <QtGui/QToolBar>
+#include <QToolBar>
 #include <tabwidget.h>
 
 class BookmarksToolBar : public QToolBar

--- a/src/bookmarksimport.cpp
+++ b/src/bookmarksimport.cpp
@@ -23,13 +23,13 @@
 #include <QMessageBox>
 #include <QApplication>
 
-#ifdef Q_WS_WIN
+#ifdef Q_OS_WIN
     #include <shlobj.h>
 #endif
 
 QString BookmarksImport::mozillaPath()
 {
-#ifdef Q_WS_WIN
+#ifdef Q_OS_WIN
         wchar_t szTemp[MAX_PATH];
     memset(szTemp, 0 , sizeof(szTemp));
     LPITEMIDLIST pidl;
@@ -54,7 +54,7 @@ QString BookmarksImport::mozillaPath()
 
 QString BookmarksImport::ieFavoritesPath()
 {
-#ifdef Q_WS_WIN
+#ifdef Q_OS_WIN
         wchar_t szTemp[MAX_PATH];
     memset(szTemp, 0 , sizeof(szTemp));
     LPITEMIDLIST pidl;
@@ -138,7 +138,7 @@ BookmarkNode *BookmarksImport::importFromIE()
 
         BookmarkNode* root = new BookmarkNode();
 
-#ifdef Q_WS_WIN
+#ifdef Q_OS_WIN
 
         CoInitialize( 0 );
     

--- a/src/browserapplication.cpp
+++ b/src/browserapplication.cpp
@@ -60,6 +60,7 @@
 #include <QtCore/QReadWriteLock>
 
 #include <QtGui/QDesktopServices>
+#include <QtCore/QStandardPaths>
 #include <QtGui/QFileOpenEvent>
 
 #include <QtNetwork/QLocalServer>
@@ -71,7 +72,7 @@
 #include <QtCore/QDebug>
 #include <QMessageBox>
 
-#ifdef Q_WS_WIN
+#ifdef Q_OS_WIN
     #include "shlwapi.h"
     #include "shellapi.h"
 #endif
@@ -272,7 +273,7 @@ BrowserApplication::~BrowserApplication()
         removeDir(BrowserApplication::dataLocation());
         removeDir(QCoreApplication::applicationDirPath() + "/QtWebSettings");
 
-#ifdef Q_WS_WIN
+#ifdef Q_OS_WIN
         HKEY hKey;
 
         wchar_t key[256];
@@ -403,14 +404,14 @@ void BrowserApplication::loadSettings()
     if (standardFontSize > 16)
         standardFontSize = 16;
     QFont standardFont = QFont(standardFontFamily, standardFontSize);
-    standardFont = qVariantValue<QFont>(settings.value(QLatin1String("standardFont"), standardFont));
+    standardFont = settings.value(QLatin1String("standardFont"), standardFont).value<QFont>();
     defaultSettings->setFontFamily(QWebSettings::StandardFont, standardFont.family());
     defaultSettings->setFontSize(QWebSettings::DefaultFontSize, standardFont.pointSize());
 
     QString fixedFontFamily = defaultSettings->fontFamily(QWebSettings::FixedFont);
     int fixedFontSize = defaultSettings->fontSize(QWebSettings::DefaultFixedFontSize);
     QFont fixedFont = QFont(fixedFontFamily, fixedFontSize);
-    fixedFont = qVariantValue<QFont>(settings.value(QLatin1String("fixedFont"), fixedFont));
+    fixedFont = settings.value(QLatin1String("fixedFont"), fixedFont).value<QFont>();
     defaultSettings->setFontFamily(QWebSettings::FixedFont, fixedFont.family());
     defaultSettings->setFontSize(QWebSettings::DefaultFixedFontSize, fixedFont.pointSize());
 
@@ -740,7 +741,7 @@ bool BrowserApplication::handleMIME(QString content, const QUrl& url)
     if (bDownloadAudioVideo)
         return false;
 
-#ifdef Q_WS_WIN
+#ifdef Q_OS_WIN
     HKEY hKey;
 
     wchar_t key[256];
@@ -941,8 +942,8 @@ QString BrowserApplication::dataLocation()
 
         return QCoreApplication::applicationDirPath()+ "/QtWebCache";
     }
-    else
-        return QDesktopServices::storageLocation(QDesktopServices::DataLocation);
+    else// TODO handle empty list
+        return QStandardPaths::standardLocations(QStandardPaths::DataLocation).first();//QDesktopServices::storageLocation(QDesktopServices::DataLocation);
 }
 
 QString BrowserApplication::downloadsLocation(bool create_dir)
@@ -951,8 +952,8 @@ QString BrowserApplication::downloadsLocation(bool create_dir)
 
     if (s_portableRunMode)
         base = QCoreApplication::applicationDirPath();
-    else
-        base = QDesktopServices::storageLocation(QDesktopServices::DocumentsLocation) ;
+    else// TODO handle empty list
+        base = QStandardPaths::standardLocations(QStandardPaths::DocumentsLocation).first();//QDesktopServices::storageLocation(QDesktopServices::DocumentsLocation) ;
 
     QString downs(tr("Downloads"));
 

--- a/src/browserapplication.h
+++ b/src/browserapplication.h
@@ -41,7 +41,7 @@
 #ifndef BROWSERAPPLICATION_H
 #define BROWSERAPPLICATION_H
 
-#include <QtGui/QApplication>
+#include <QtWidgets/QApplication>
 
 #include <QtCore/QUrl>
 #include <QtCore/QPointer>

--- a/src/browsermainwindow.cpp
+++ b/src/browsermainwindow.cpp
@@ -61,21 +61,21 @@
 #include <QtCore/QMetaEnum>
 #include <QTextCodec>
 #include <QProcess>
-#include <QtGui/QDesktopWidget>
-#include <QtGui/QFileDialog>
-#include <QtGui/QPlainTextEdit>
-#include <QtGui/QPrintDialog>
-#include <QtGui/QPrinter>
-#include <QtGui/QMenuBar>
-#include <QtGui/QMessageBox>
-#include <QtGui/QStatusBar>
-#include <QtGui/QToolBar>
-#include <QtGui/QInputDialog>
+#include <QtWidgets/QDesktopWidget>
+#include <QtWidgets/QFileDialog>
+#include <QtWidgets/QPlainTextEdit>
+#include <QtPrintSupport/QPrintDialog>
+#include <QtPrintSupport/QPrinter>
+#include <QtWidgets/QMenuBar>
+#include <QtWidgets/QMessageBox>
+#include <QtWidgets/QStatusBar>
+#include <QtWidgets/QToolBar>
+#include <QtWidgets/QInputDialog>
 #include <QtGui/QDesktopServices>
 #include <QThread>
 #include <QFile>
 #include <QStyleFactory>
-#include <QtWebKit/QWebFrame>
+#include <QtWebKitWidgets/QWebFrame>
 #include <QtWebKit/QWebHistory>
 #include <tabwidget.h>
 #include <QtCore/QDebug>
@@ -425,7 +425,7 @@ void BrowserMainWindow::setupMenu()
     BookmarksManager *bookmarksManager = BrowserApplication::bookmarksManager();
     QMenu *importMenu = fileMenu->addMenu(  cmds.ImportTitle() );
 
-#ifdef Q_WS_WIN
+#ifdef Q_OS_WIN
     // Import from Internet Explorer
     QAction* import_ie = new QAction(cmds.ImportIETitle(), this);
     import_ie->setShortcuts(cmds.ImportIEShortcuts());
@@ -922,7 +922,7 @@ void BrowserMainWindow::setupMenu()
     toolsMenu->addAction(search);
     this->addAction(search);
 
-#ifdef Q_WS_WIN
+#ifdef Q_OS_WIN
     // Enable Virtual Keyboard
     QAction* keyboard = new QAction(cmds.KeyboardTitle(), this);
     if (showMenuIcons())
@@ -967,7 +967,7 @@ void BrowserMainWindow::setupMenu()
     // Help Menu
     QMenu *helpMenu = menuBar()->addMenu(cmds.HelpTitle());
 
-#ifdef Q_WS_WIN
+#ifdef Q_OS_WIN
     // Help F1
     QAction* help = new QAction(cmds.HelpTitle(), this);
     if (showMenuIcons())
@@ -1720,7 +1720,7 @@ void BrowserMainWindow::slotFilePrint()
     printRequested(currentTab()->page()->mainFrame());
 }
 
-#include <QtGui/QPrintPreviewDialog>
+#include <QtPrintSupport/QPrintPreviewDialog>
 
 void BrowserMainWindow::slotFilePrintPreview()
 {
@@ -1989,11 +1989,11 @@ extern bool ShellOpenApp(QString app, QString cmd);
 
 void BrowserMainWindow::slotViewPageSource()
 {
-#ifdef Q_WS_WIN
+#ifdef Q_OS_WIN
     QLatin1String notepad("NOTEPAD.EXE");
 #else
 
-#ifdef Q_WS_MAC
+#ifdef Q_OS_MAC
     QLatin1String notepad("Open");
     #else
         QLatin1String notepad("gedit");

--- a/src/browsermainwindow.h
+++ b/src/browsermainwindow.h
@@ -41,7 +41,7 @@
 #ifndef BROWSERMAINWINDOW_H
 #define BROWSERMAINWINDOW_H
 
-#include <QtGui/QMainWindow>
+#include <QtWidgets/QMainWindow>
 #include <QtGui/QIcon>
 #include <QtCore/QUrl>
 

--- a/src/certificateinfo.cpp
+++ b/src/certificateinfo.cpp
@@ -77,8 +77,8 @@ void CertificateInfo::setCertificateChain(const QList<QSslCertificate> &chain)
     for (int i = 0; i < chain.size(); ++i) {
         const QSslCertificate &cert = chain.at(i);
         form->certificationPathView->addItem(tr("%1%2 (%3)").arg(!i ? QString() : tr("Issued by: "))
-                                             .arg(cert.subjectInfo(QSslCertificate::Organization))
-                                             .arg(cert.subjectInfo(QSslCertificate::CommonName)));
+                                             .arg(cert.subjectInfo(QSslCertificate::Organization).join(", "))
+                                             .arg(cert.subjectInfo(QSslCertificate::CommonName).join(", ")));
     }
 
     form->certificationPathView->setCurrentRow(0);
@@ -90,23 +90,23 @@ void CertificateInfo::updateCertificateInfo(int index)
     if (index >= 0 && index < chain.size()) {
         const QSslCertificate &cert = chain.at(index);
         QStringList lines;
-        lines << tr("Issued to:   %1").arg(cert.subjectInfo(QSslCertificate::Organization))
-              << tr("Issued by:  %1").arg(cert.issuerInfo(QSslCertificate::Organization))
+        lines << tr("Issued to:   %1").arg(cert.subjectInfo(QSslCertificate::Organization).join(", "))
+              << tr("Issued by:  %1").arg(cert.issuerInfo(QSslCertificate::Organization).join(", "))
               << tr("Valid from:  %1 to %2").arg(cert.effectiveDate().date().toString("MMM dd, yyyy")).arg(cert.expiryDate().date().toString("MMM dd, yyyy"))
               << tr("")
-              << tr("Organization: %1").arg(cert.subjectInfo(QSslCertificate::Organization))
-              << tr("Subunit: %1").arg(cert.subjectInfo(QSslCertificate::OrganizationalUnitName))
-              << tr("Country: %1").arg(cert.subjectInfo(QSslCertificate::CountryName))
-              << tr("Locality: %1").arg(cert.subjectInfo(QSslCertificate::LocalityName))
-              << tr("State/Province: %1").arg(cert.subjectInfo(QSslCertificate::StateOrProvinceName))
-              << tr("Common Name: %1").arg(cert.subjectInfo(QSslCertificate::CommonName))
+              << tr("Organization: %1").arg(cert.subjectInfo(QSslCertificate::Organization).join(", "))
+              << tr("Subunit: %1").arg(cert.subjectInfo(QSslCertificate::OrganizationalUnitName).join(", "))
+              << tr("Country: %1").arg(cert.subjectInfo(QSslCertificate::CountryName).join(", "))
+              << tr("Locality: %1").arg(cert.subjectInfo(QSslCertificate::LocalityName).join(", "))
+              << tr("State/Province: %1").arg(cert.subjectInfo(QSslCertificate::StateOrProvinceName).join(", "))
+              << tr("Common Name: %1").arg(cert.subjectInfo(QSslCertificate::CommonName).join(", "))
               << QString()
-              << tr("Issuer Organization: %1").arg(cert.issuerInfo(QSslCertificate::Organization))
-              << tr("Issuer Unit Name: %1").arg(cert.issuerInfo(QSslCertificate::OrganizationalUnitName))
-              << tr("Issuer Country: %1").arg(cert.issuerInfo(QSslCertificate::CountryName))
-              << tr("Issuer Locality: %1").arg(cert.issuerInfo(QSslCertificate::LocalityName))
-              << tr("Issuer State/Province: %1").arg(cert.issuerInfo(QSslCertificate::StateOrProvinceName))
-              << tr("Issuer Common Name: %1").arg(cert.issuerInfo(QSslCertificate::CommonName));
+              << tr("Issuer Organization: %1").arg(cert.issuerInfo(QSslCertificate::Organization).join(", "))
+              << tr("Issuer Unit Name: %1").arg(cert.issuerInfo(QSslCertificate::OrganizationalUnitName).join(", "))
+              << tr("Issuer Country: %1").arg(cert.issuerInfo(QSslCertificate::CountryName).join(", "))
+              << tr("Issuer Locality: %1").arg(cert.issuerInfo(QSslCertificate::LocalityName).join(", "))
+              << tr("Issuer State/Province: %1").arg(cert.issuerInfo(QSslCertificate::StateOrProvinceName).join(", "))
+              << tr("Issuer Common Name: %1").arg(cert.issuerInfo(QSslCertificate::CommonName).join(", "));
         foreach (QString line, lines)
             form->certificateInfoView->addItem(line);
     } else {

--- a/src/certificateinfo.h
+++ b/src/certificateinfo.h
@@ -20,7 +20,7 @@
 #ifndef CERTIFICATEINFO_H
 #define CERTIFICATEINFO_H
 
-#include <QtGui/QDialog>
+#include <QtWidgets/QDialog>
 #include <QtNetwork/QSslCertificate>
 #include <QtNetwork/QSslError>
 

--- a/src/chasewidget.cpp
+++ b/src/chasewidget.cpp
@@ -42,7 +42,7 @@
 
 #include <QtCore/QPoint>
 
-#include <QtGui/QApplication>
+#include <QtWidgets/QApplication>
 #include <QtGui/QHideEvent>
 #include <QtGui/QPainter>
 #include <QtGui/QPaintEvent>

--- a/src/chasewidget.h
+++ b/src/chasewidget.h
@@ -41,7 +41,7 @@
 #ifndef CHASEWIDGET_H
 #define CHASEWIDGET_H
 
-#include <QtGui/QWidget>
+#include <QtWidgets/QWidget>
 
 #include <QtCore/QSize>
 #include <QtGui/QColor>

--- a/src/cookiejar.cpp
+++ b/src/cookiejar.cpp
@@ -49,16 +49,17 @@
 #include <QtCore/QSettings>
 #include <QtCore/QUrl>
 
-#include <QtGui/QCompleter>
+#include <QtWidgets/QCompleter>
 #include <QtGui/QFont>
 #include <QtGui/QFontMetrics>
-#include <QtGui/QHeaderView>
+#include <QtWidgets/QHeaderView>
 #include <QtGui/QKeyEvent>
-#include <QtGui/QSortFilterProxyModel>
+#include <QtCore/QSortFilterProxyModel>
 
 #include <QtWebKit/QWebSettings>
 
 #include <QtCore/QDebug>
+#include <QNetworkCookie>
 
 static const unsigned int JAR_VERSION = 23;
 
@@ -492,7 +493,9 @@ bool CookieModel::removeRows(int row, int count, const QModelIndex &parent)
 
 void CookieModel::cookiesChanged()
 {
-    reset();
+//    reset();
+    beginResetModel();
+    endResetModel();
 }
 
 CookiesDialog::CookiesDialog(CookieJar *cookieJar, QWidget *parent) : QDialog(parent)
@@ -722,26 +725,32 @@ void CookiesExceptionsDialog::block()
 {
     if (domainLineEdit->text().isEmpty())
         return;
+    m_exceptionsModel->beginResetModel();
     m_exceptionsModel->m_blockedCookies.append(domainLineEdit->text());
     m_cookieJar->setBlockedCookies(m_exceptionsModel->m_blockedCookies);
-    m_exceptionsModel->reset();
+//    m_exceptionsModel->reset();
+    m_exceptionsModel->endResetModel();
 }
 
 void CookiesExceptionsDialog::allow()
 {
     if (domainLineEdit->text().isEmpty())
         return;
+    m_exceptionsModel->beginResetModel();
     m_exceptionsModel->m_allowedCookies.append(domainLineEdit->text());
     m_cookieJar->setAllowedCookies(m_exceptionsModel->m_allowedCookies);
-    m_exceptionsModel->reset();
+//    m_exceptionsModel->reset();
+    m_exceptionsModel->endResetModel();
 }
 
 void CookiesExceptionsDialog::allowForSession()
 {
     if (domainLineEdit->text().isEmpty())
         return;
+    m_exceptionsModel->beginResetModel();
     m_exceptionsModel->m_sessionCookies.append(domainLineEdit->text());
     m_cookieJar->setAllowForSessionCookies(m_exceptionsModel->m_sessionCookies);
-    m_exceptionsModel->reset();
+//    m_exceptionsModel->reset();
+    m_exceptionsModel->endResetModel();
 }
 

--- a/src/cookiejar.h
+++ b/src/cookiejar.h
@@ -46,8 +46,8 @@
 #include <QtCore/QAbstractItemModel>
 #include <QtCore/QStringList>
 
-#include <QtGui/QDialog>
-#include <QtGui/QTableView>
+#include <QtWidgets/QDialog>
+#include <QtWidgets/QTableView>
 
 QT_BEGIN_NAMESPACE
 class QSortFilterProxyModel;

--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -47,9 +47,9 @@
 
 #include <QtCore/QMetaEnum>
 #include <QtCore/QSettings>
-#include <QtGui/QFileDialog>
-#include <QtGui/QHeaderView>
-#include <QtGui/QFileIconProvider>
+#include <QtWidgets/QFileDialog>
+#include <QtWidgets/QHeaderView>
+#include <QtWidgets/QFileIconProvider>
 #include <QtGui/QDesktopServices>
 #include <QMessageBox>
 #include <QtCore/QDebug>

--- a/src/edittableview.h
+++ b/src/edittableview.h
@@ -41,7 +41,7 @@
 #ifndef EDITTABLEVIEW_H
 #define EDITTABLEVIEW_H
 
-#include <QtGui/QTableView>
+#include <QtWidgets/QTableView>
 
 class EditTableView : public QTableView
 {

--- a/src/edittreeview.h
+++ b/src/edittreeview.h
@@ -41,7 +41,7 @@
 #ifndef EDITTREEVIEW_H
 #define EDITTREEVIEW_H
 
-#include <QtGui/QTreeView>
+#include <QTreeView>
 
 class EditTreeView : public QTreeView
 {

--- a/src/exlineedit.cpp
+++ b/src/exlineedit.cpp
@@ -49,16 +49,16 @@
 
 #include <QtCore/QEvent>
 
-#include <QtGui/QApplication>
-#include <QtGui/QCompleter>
+#include <QtWidgets/QApplication>
+#include <QtWidgets/QCompleter>
 #include <QtGui/QFocusEvent>
-#include <QtGui/QHBoxLayout>
-#include <QtGui/QLabel>
-#include <QtGui/QLineEdit>
+#include <QtWidgets/QHBoxLayout>
+#include <QtWidgets/QLabel>
+#include <QtWidgets/QLineEdit>
 #include <QtGui/QPainter>
-#include <QtGui/QStyle>
-#include <QtGui/QStyleOptionFrameV2>
-#include <QtGui/QMessageBox>
+#include <QtWidgets/QStyle>
+#include <QtWidgets/QStyleOptionFrameV2>
+#include <QtWidgets/QMessageBox>
 
 #include <QtCore/QDebug>
 

--- a/src/exlineedit.h
+++ b/src/exlineedit.h
@@ -42,10 +42,10 @@
 #define EXLINEEDIT_H
 
 #include <QtCore/QUrl>
-#include <QtGui/QWidget>
-#include <QtGui/QStyleOptionFrame>
-#include <QtGui/QAbstractButton>
-#include <QtGui/QLineEdit>
+#include <QWidget>
+#include <QStyleOptionFrame>
+#include <QAbstractButton>
+#include <QLineEdit>
 
 /* Clear button on the right hand side of the search widget.
     Hidden by default   "A circle with an X in it" */

--- a/src/findwidget.cpp
+++ b/src/findwidget.cpp
@@ -41,14 +41,14 @@
 ****************************************************************************/
 #include "findwidget.h"
 
-#include <QtGui/QApplication>
-#include <QtGui/QCheckBox>
+#include <QtWidgets/QApplication>
+#include <QtWidgets/QCheckBox>
 #include <QtGui/QHideEvent>
 #include <QtGui/QKeyEvent>
-#include <QtGui/QLabel>
-#include <QtGui/QLayout>
-#include <QtGui/QLineEdit>
-#include <QtGui/QToolButton>
+#include <QtWidgets/QLabel>
+#include <QtWidgets/QLayout>
+#include <QtWidgets/QLineEdit>
+#include <QtWidgets/QToolButton>
 
 QT_BEGIN_NAMESPACE
 

--- a/src/findwidget.h
+++ b/src/findwidget.h
@@ -42,7 +42,7 @@
 #ifndef FINDWIDGET_H
 #define FINDWIDGET_H
 
-#include <QtGui/QWidget>
+#include <QtWidgets/QWidget>
 
 QT_BEGIN_NAMESPACE
 

--- a/src/googlesuggest.cpp
+++ b/src/googlesuggest.cpp
@@ -40,13 +40,13 @@
 ****************************************************************************/
 
 #include <QtCore>
-#include <QtGui>
+#include <QtWidgets>
 #include <QtNetwork>
 #include <QSettings>
 
 #include "googlesuggest.h"
 
-#ifdef Q_WS_WIN
+#ifdef Q_OS_WIN
     #include "windows.h"
 #endif
 
@@ -103,7 +103,7 @@ GSuggestCompletion::GSuggestCompletion(QLineEdit *parent): QObject(parent), edit
     if (settings.value(QLatin1String("autoProxy"), false).toBool()) 
     {
 
-#ifdef Q_WS_WIN
+#ifdef Q_OS_WIN
         QNetworkProxy pxy;
         HKEY hKey;
         wchar_t key[256];

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -55,8 +55,8 @@
 #include <QtCore/QtAlgorithms>
 
 #include <QtGui/QClipboard>
-#include <QtGui/QHeaderView>
-#include <QtGui/QStyle>
+#include <QtWidgets/QHeaderView>
+#include <QtWidgets/QStyle>
 
 #include <QtWebKit/QWebHistoryInterface>
 #include <QtWebKit/QWebSettings>
@@ -401,7 +401,9 @@ HistoryModel::HistoryModel(HistoryManager *history, QObject *parent)
 
 void HistoryModel::historyReset()
 {
-    reset();
+    beginResetModel();
+//    reset();
+    endResetModel();
 }
 
 void HistoryModel::entryAdded()
@@ -814,7 +816,9 @@ QVariant HistoryFilterModel::headerData(int section, Qt::Orientation orientation
 void HistoryFilterModel::sourceReset()
 {
     m_loaded = false;
-    reset();
+    beginResetModel();
+//    reset();
+    endResetModel();
 }
 
 int HistoryFilterModel::rowCount(const QModelIndex &parent) const
@@ -946,7 +950,11 @@ bool HistoryFilterModel::removeRows(int row, int count, const QModelIndex &paren
                 this, SLOT(sourceRowsRemoved(const QModelIndex &, int, int)));
     m_loaded = false;
     if (oldCount - count != rowCount())
-        reset();
+    {
+        beginResetModel();
+//        reset();
+        endResetModel();
+    }
     return true;
 }
 
@@ -1004,7 +1012,7 @@ QModelIndex HistoryCompletionModel::index(int row, int column, const QModelIndex
     if (row < 0 || row >= rowCount(parent)
         || column < 0 || column >= columnCount(parent))
         return QModelIndex();
-    return createIndex(row, column, 0);
+    return createIndex(row, column);
 }
 
 QModelIndex HistoryCompletionModel::parent(const QModelIndex &) const
@@ -1032,12 +1040,16 @@ void HistoryCompletionModel::setSourceModel(QAbstractItemModel *newSourceModel)
                 this, SLOT(sourceReset()));
     }
 
-    reset();
+    beginResetModel();
+//    reset();
+    endResetModel();
 }
 
 void HistoryCompletionModel::sourceReset()
 {
-    reset();
+    beginResetModel();
+//    reset();
+    endResetModel();
 }
 
 HistoryTreeModel::HistoryTreeModel(QAbstractItemModel *sourceModel, QObject *parent)
@@ -1152,7 +1164,7 @@ QModelIndex HistoryTreeModel::index(int row, int column, const QModelIndex &pare
         return QModelIndex();
 
     if (!parent.isValid())
-        return createIndex(row, column, 0);
+        return createIndex(row, column);
     return createIndex(row, column, parent.row() + 1);
 }
 
@@ -1161,7 +1173,7 @@ QModelIndex HistoryTreeModel::parent(const QModelIndex &index) const
     int offset = index.internalId();
     if (offset == 0 || !index.isValid())
         return QModelIndex();
-    return createIndex(offset - 1, 0, 0);
+    return createIndex(offset - 1, 0);
 }
 
 bool HistoryTreeModel::hasChildren(const QModelIndex &parent) const
@@ -1222,13 +1234,17 @@ void HistoryTreeModel::setSourceModel(QAbstractItemModel *newSourceModel)
                 this, SLOT(sourceRowsRemoved(const QModelIndex &, int, int)));
     }
 
-    reset();
+    beginResetModel();
+//    reset();
+    endResetModel();
 }
 
 void HistoryTreeModel::sourceReset()
 {
     m_sourceRowCache.clear();
-    reset();
+    beginResetModel();
+//    reset();
+    endResetModel();
 }
 
 void HistoryTreeModel::sourceRowsInserted(const QModelIndex &parent, int start, int end)
@@ -1236,8 +1252,11 @@ void HistoryTreeModel::sourceRowsInserted(const QModelIndex &parent, int start, 
     Q_UNUSED(parent); // Avoid warnings when compiling release
     Q_ASSERT(!parent.isValid());
     if (start != 0 || start != end) {
+        beginResetModel();
         m_sourceRowCache.clear();
-        reset();
+    //    reset();
+        endResetModel();
+
         return;
     }
 
@@ -1281,8 +1300,11 @@ void HistoryTreeModel::sourceRowsRemoved(const QModelIndex &parent, int start, i
         it = qLowerBound(m_sourceRowCache.begin(), m_sourceRowCache.end(), i);
         // playing it safe
         if (it == m_sourceRowCache.end()) {
+            beginResetModel();
             m_sourceRowCache.clear();
-            reset();
+        //    reset();
+            endResetModel();
+
             return;
         }
 

--- a/src/history.h
+++ b/src/history.h
@@ -49,7 +49,7 @@
 #include <QtCore/QTimer>
 #include <QtCore/QUrl>
 
-#include <QtGui/QSortFilterProxyModel>
+#include <QtCore/QSortFilterProxyModel>
 
 #include <QWebHistoryInterface>
 

--- a/src/modelmenu.h
+++ b/src/modelmenu.h
@@ -41,7 +41,7 @@
 #ifndef MODELMENU_H
 #define MODELMENU_H
 
-#include <QtGui/QMenu>
+#include <QtWidgets/QMenu>
 #include <QtCore/QAbstractItemModel>
 
 // A QMenu that is dynamically populated from a QAbstractItemModel

--- a/src/networkaccessmanager.cpp
+++ b/src/networkaccessmanager.cpp
@@ -49,9 +49,9 @@
 #include "cookiejar.h"
 #include <QtCore/QSettings>
 
-#include <QtGui/QDialog>
-#include <QtGui/QMessageBox>
-#include <QtGui/QStyle>
+#include <QtWidgets/QDialog>
+#include <QtWidgets/QMessageBox>
+#include <QtWidgets/QStyle>
 #include <QtGui/QTextDocument>
 
 #include <QtNetwork/QAuthenticator>
@@ -67,7 +67,7 @@
 
 #include <qnetworkdiskcache.h>
 
-#ifdef Q_WS_WIN
+#ifdef Q_OS_WIN
     #include <windows.h>
 #endif
 
@@ -142,7 +142,7 @@ void NetworkAccessManager::loadSettings()
     {
         m_useProxy = false;
 
-#ifdef Q_WS_WIN
+#ifdef Q_OS_WIN
         HKEY hKey;
         wchar_t key[256];
         wcscpy(key, L"Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\");
@@ -249,7 +249,8 @@ void NetworkAccessManager::authenticationRequired(QNetworkReply *reply, QAuthent
     passwordDialog.iconLabel->setPixmap(mainWindow->style()->standardIcon(QStyle::SP_MessageBoxQuestion, 0, mainWindow).pixmap(32, 32));
 
     QString introMessage = tr("<qt>Enter username and password for \"%1\" at %2</qt>");
-    introMessage = introMessage.arg(Qt::escape(reply->url().toString())).arg(Qt::escape(reply->url().toString()));
+    introMessage = introMessage.arg(reply->url().toString().toHtmlEscaped().arg(reply->url().toString().toHtmlEscaped()));
+        //Qt::escape(reply->url().toString())).arg(Qt::escape(reply->url().toString()));
     passwordDialog.introLabel->setText(introMessage);
     passwordDialog.introLabel->setWordWrap(true);
 
@@ -273,7 +274,7 @@ void NetworkAccessManager::proxyAuthenticationRequired(const QNetworkProxy &prox
     proxyDialog.iconLabel->setPixmap(mainWindow->style()->standardIcon(QStyle::SP_MessageBoxQuestion, 0, mainWindow).pixmap(32, 32));
 
     QString introMessage = tr("<qt>Connect to proxy \"%1\" using:</qt>");
-    introMessage = introMessage.arg(Qt::escape(proxy.hostName()));
+    introMessage = introMessage.arg(proxy.hostName().toHtmlEscaped());//Qt::escape(proxy.hostName()));
     proxyDialog.introLabel->setText(introMessage);
     proxyDialog.introLabel->setWordWrap(true);
 

--- a/src/passwords.cpp
+++ b/src/passwords.cpp
@@ -18,8 +18,8 @@
  */
 
 #include "passwords.h"
-#include <QtGui/QSortFilterProxyModel>
-#include <QtGui/QHeaderView>
+#include <QtCore/QSortFilterProxyModel>
+#include <QtWidgets/QHeaderView>
 #include <QSettings>
 #include <QInputDialog>
 #include <QMessageBox>

--- a/src/searches.cpp
+++ b/src/searches.cpp
@@ -19,8 +19,8 @@
  */
 
 #include "searches.h"
-#include <QtGui/QSortFilterProxyModel>
-#include <QtGui/QHeaderView>
+#include <QtCore/QSortFilterProxyModel>
+#include <QtWidgets/QHeaderView>
 #include <QSettings>
 
 SearchesModel::SearchesModel(QObject *parent)
@@ -136,10 +136,10 @@ int SearchesModel::addRow(QString name, QString value)
     if (oldIndex != -1) { // prevent from inserting more than one unique row
         return oldIndex;
     } else {
+        beginResetModel();
         m_searchProviders->append(pair);
         int index = m_searchProviders->indexOf(pair);
-        beginResetModel();
-        reset();
+//        reset();
         endResetModel();
         return index;
     }
@@ -147,13 +147,13 @@ int SearchesModel::addRow(QString name, QString value)
 
 void SearchesModel::loadDefaultProviders()
 {
+    beginResetModel();
     m_searchProviders->clear();
     m_searchProviders->append(QPair<QString, QString>("Google", "http://www.google.com/search?q="));
     m_searchProviders->append(QPair<QString, QString>("Yahoo", "http://search.yahoo.com/search?p="));
     m_searchProviders->append(QPair<QString, QString>("Bing", "http://www.bing.com/search?q="));
     m_searchProviders->append(QPair<QString, QString>("Cuil", "http://www.cuil.com/search?q="));
-    beginResetModel();
-    reset();
+//    reset();
     endResetModel();
 }
 

--- a/src/searchlineedit.cpp
+++ b/src/searchlineedit.cpp
@@ -42,9 +42,9 @@
 
 #include <QtGui/QPainter>
 #include <QtGui/QMouseEvent>
-#include <QtGui/QMenu>
-#include <QtGui/QStyle>
-#include <QtGui/QStyleOptionFrameV2>
+#include <QtWidgets/QMenu>
+#include <QtWidgets/QStyle>
+#include <QtWidgets/QStyleOptionFrameV2>
 
 /*
     Search icon on the left hand side of the search widget

--- a/src/searchlineedit.h
+++ b/src/searchlineedit.h
@@ -43,7 +43,7 @@
 
 #include "urllineedit.h"
 
-#include <QtGui/QLineEdit>
+#include <QLineEdit>
 
 QT_BEGIN_NAMESPACE
 class QMenu;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -50,7 +50,7 @@
 #include "webpage.h"
 
 #include <QtCore/QSettings>
-#include <QtGui/QtGui>
+#include <QtWidgets/QtWidgets>
 #include <QtWebKit/QtWebKit>
 #include <QSysInfo>
 #include <QInputDialog>
@@ -140,10 +140,10 @@ void SettingsDialog::setProxyEnabled(bool state)
 
 QString DefaultAppStyle()
 {
-#ifdef Q_WS_WIN
+#ifdef Q_OS_WIN
     return QLatin1String("Windows .NET");
 #else
-    #ifdef Q_WS_MAC
+    #ifdef Q_OS_MAC
         return QLatin1String("Macintosh (aqua)");
     #else
         return QLatin1String("GTK+");
@@ -212,7 +212,7 @@ void SettingsDialog::loadDefaults()
     tbReset->setChecked( false );
     tbJavaScript->setChecked( false );
 
-#ifndef Q_WS_WIN
+#ifndef Q_OS_WIN
     proxyAuto->setVisible(false);
 #endif
 
@@ -319,8 +319,8 @@ void SettingsDialog::loadFromSettings()
 
     // Appearance
     settings.beginGroup(QLatin1String("websettings"));
-    fixedFont = qVariantValue<QFont>(settings.value(QLatin1String("fixedFont"), fixedFont));
-    standardFont = qVariantValue<QFont>(settings.value(QLatin1String("standardFont"), standardFont));
+    fixedFont = settings.value(QLatin1String("fixedFont"), fixedFont).value<QFont>();
+    standardFont = settings.value(QLatin1String("standardFont"), standardFont).value<QFont>();
 
     standardLabel->setText(QString(QLatin1String("%1 %2")).arg(standardFont.family()).arg(standardFont.pointSize()));
     fixedLabel->setText(QString(QLatin1String("%1 %2")).arg(fixedFont.family()).arg(fixedFont.pointSize()));
@@ -344,11 +344,11 @@ void SettingsDialog::loadFromSettings()
 
     chkExtViewer->setChecked( settings.value(QLatin1String("useExtViewer"), chkExtViewer->isChecked()).toBool());
 
-#ifdef Q_WS_WIN
+#ifdef Q_OS_WIN
         QLatin1String extViewer("NOTEPAD.EXE");
 #else
 
-#ifdef Q_WS_MAC
+#ifdef Q_OS_MAC
         QLatin1String extViewer("Open");
 #else
         QLatin1String extViewer("gedit");
@@ -771,7 +771,7 @@ void SettingsDialog::editShortcuts()
 
 void SettingsDialog::chooseExtViewer()
 {
-#ifdef Q_WS_WIN
+#ifdef Q_OS_WIN
     QString filter(tr("Applications (*.exe);;All files (*.*)"));
 #else
     QString filter = tr("All files (*.*)");

--- a/src/settings.h
+++ b/src/settings.h
@@ -41,7 +41,7 @@
 #ifndef SETTINGS_H
 #define SETTINGS_H
 
-#include <QtGui/QDialog>
+#include <QtWidgets/QDialog>
 #include "ui_settings.h"
 
 class SettingsDialog : public QDialog, public Ui_Settings

--- a/src/shortcuts.cpp
+++ b/src/shortcuts.cpp
@@ -18,8 +18,8 @@
  */
 
 #include "shortcuts.h"
-#include <QtGui/QSortFilterProxyModel>
-#include <QtGui/QHeaderView>
+#include <QtCore/QSortFilterProxyModel>
+#include <QtWidgets/QHeaderView>
 #include <QSettings>
 #include <QMessageBox>
 

--- a/src/squeezelabel.h
+++ b/src/squeezelabel.h
@@ -41,7 +41,7 @@
 #ifndef SQUEEZELABEL_H
 #define SQUEEZELABEL_H
 
-#include <QtGui/QLabel>
+#include <QtWidgets/QLabel>
 
 class SqueezeLabel : public QLabel
 {

--- a/src/tabbar.cpp
+++ b/src/tabbar.cpp
@@ -48,19 +48,22 @@
 #include "commands.h"
 
 #include <QtGui/QClipboard>
-#include <QtGui/QCompleter>
-#include <QtGui/QListView>
-#include <QtGui/QMenu>
-#include <QtGui/QMessageBox>
+#include <QtWidgets/QCompleter>
+#include <QtWidgets/QListView>
+#include <QtWidgets/QMenu>
+#include <QtWidgets/QMessageBox>
 #include <QtGui/QMouseEvent>
-#include <QtGui/QStackedWidget>
-#include <QtGui/QStyle>
-#include <QtGui/QToolButton>
+#include <QtWidgets/QStackedWidget>
+#include <QtWidgets/QStyle>
+#include <QtWidgets/QToolButton>
 #include <QFile>
 #include <QtCore/QDebug>
 #include <QBuffer>
 #include <QLabel>
 #include <QMovie>
+#include <QWidget>// for QDrag
+#include <QDrag>
+#include <QMimeData>
 
 TabShortcut::TabShortcut(int tab, const QKeySequence &key, QWidget *parent)
     : QShortcut(key, parent)

--- a/src/tabbar.h
+++ b/src/tabbar.h
@@ -41,11 +41,11 @@
 #ifndef TABBAR_H
 #define TABBAR_H
 
-#include <QtGui/QTabBar>
+#include <QtWidgets/QTabBar>
 
 class QUrl;
 
-#include <QtGui/QShortcut>
+#include <QtWidgets/QShortcut>
 /*
     Tab bar with a few more features such as a context menu and shortcuts
  */
@@ -107,7 +107,7 @@ private:
     bool m_showTabBarWhenOneTab;
 };
 
-#include <QtWebKit/QWebPage>
+#include <QtWebKitWidgets/QWebPage>
 
 QT_BEGIN_NAMESPACE
 class QAction;

--- a/src/tabwidget.cpp
+++ b/src/tabwidget.cpp
@@ -49,14 +49,14 @@
 #include "commands.h"
 
 #include <QtGui/QClipboard>
-#include <QtGui/QCompleter>
-#include <QtGui/QListView>
-#include <QtGui/QMenu>
-#include <QtGui/QMessageBox>
+#include <QtWidgets/QCompleter>
+#include <QtWidgets/QListView>
+#include <QtWidgets/QMenu>
+#include <QtWidgets/QMessageBox>
 #include <QtGui/QMouseEvent>
-#include <QtGui/QStackedWidget>
-#include <QtGui/QStyle>
-#include <QtGui/QToolButton>
+#include <QtWidgets/QStackedWidget>
+#include <QtWidgets/QStyle>
+#include <QtWidgets/QToolButton>
 #include <QFile>
 #include <QtCore/QDebug>
 #include <QBuffer>

--- a/src/tabwidget.h
+++ b/src/tabwidget.h
@@ -44,7 +44,7 @@
 #include "tabbar.h"
 
 #include <QtCore/QUrl>
-#include <QtGui/QTabWidget>
+#include <QtWidgets/QTabWidget>
 QT_BEGIN_NAMESPACE
 class QLineEdit;
 class QMenu;

--- a/src/toolbarsearch.cpp
+++ b/src/toolbarsearch.cpp
@@ -43,10 +43,11 @@
 #include <QtCore/QSettings>
 #include <QtCore/QUrl>
 
-#include <QtGui/QCompleter>
-#include <QtGui/QMenu>
-#include <QtGui/QStringListModel>
+#include <QtWidgets/QCompleter>
+#include <QtWidgets/QMenu>
+#include <QtCore/QStringListModel>
 #include <QtWebKit/QWebSettings>
+#include <QUrlQuery>
 #include "searches.h"
 #include "googlesuggest.h"
 
@@ -170,31 +171,33 @@ void ToolbarSearch::searchNow()
     }
 
     QUrl url;
+    QUrlQuery urlQuery;
     if (inactiveText() == SEARCH_GOOGLE)
     {
         url.setUrl(QLatin1String("http://www.google.com/search"));
-        url.addQueryItem(QLatin1String("q"), searchText);
-        url.addQueryItem(QLatin1String("ie"), QLatin1String("UTF-8"));
-        url.addQueryItem(QLatin1String("oe"), QLatin1String("UTF-8"));
+
+        urlQuery.addQueryItem(QLatin1String("q"), searchText);
+        urlQuery.addQueryItem(QLatin1String("ie"), QLatin1String("UTF-8"));
+        urlQuery.addQueryItem(QLatin1String("oe"), QLatin1String("UTF-8"));
     }
     else
     if (inactiveText() == SEARCH_CUIL)
     {
         url.setUrl(QLatin1String("http://www.cuil.com/search"));
-        url.addQueryItem(QLatin1String("q"), searchText);
+        urlQuery.addQueryItem(QLatin1String("q"), searchText);
     }
     else
     if (inactiveText() == SEARCH_YAHOO)
     {
         url.setUrl(QLatin1String("http://search.yahoo.com/search"));
-        url.addQueryItem(QLatin1String("p"), searchText);
-        url.addQueryItem(QLatin1String("ei"), QLatin1String("UTF-8"));
+        urlQuery.addQueryItem(QLatin1String("p"), searchText);
+        urlQuery.addQueryItem(QLatin1String("ei"), QLatin1String("UTF-8"));
     }
     else
     if (inactiveText() == SEARCH_BING)
     {
         url.setUrl(QLatin1String("http://www.bing.com/search"));
-        url.addQueryItem(QLatin1String("q"), searchText);
+        urlQuery.addQueryItem(QLatin1String("q"), searchText);
     }
     else
     {
@@ -213,12 +216,13 @@ void ToolbarSearch::searchNow()
         settings.endGroup();
     }
 
-    url.addQueryItem(QLatin1String("client"), QLatin1String("QtWeb"));
+    urlQuery.addQueryItem(QLatin1String("client"), QLatin1String("QtWeb"));
 
     if (!keyword_provider.isEmpty())
     {
         setInactiveText(keyword_provider);
     }
+    url.setQuery(urlQuery);
 
     emit search(url);
 }

--- a/src/torrent/torrent.pro
+++ b/src/torrent/torrent.pro
@@ -26,4 +26,4 @@ SOURCES += addtorrentdialog.cpp \
 FORMS += forms/addtorrentform.ui
 RESOURCES += icons.qrc
 
-QT += network
+QT += network widgets

--- a/src/torrent/torrentwindow.cpp
+++ b/src/torrent/torrentwindow.cpp
@@ -40,7 +40,10 @@
 **
 ****************************************************************************/
 
-#include <QtGui>
+#include <QtWidgets>
+#include <QtWidgets>
+#include <QTreeWidget>
+#include <QItemDelegate>
 
 #include "addtorrentdialog.h"
 #include "torrentwindow.h"

--- a/src/torrent/trackerclient.h
+++ b/src/torrent/trackerclient.h
@@ -45,7 +45,9 @@
 #include <QList>
 #include <QObject>
 #include <QHostAddress>
-#include <QHttp>
+#include <QtHttp>
+// In Qt 5 no more QHttp
+//#include <QNetworkAccessManager>
 
 #include "metainfo.h"
 #include "torrentclient.h"

--- a/src/urllineedit.cpp
+++ b/src/urllineedit.cpp
@@ -48,16 +48,19 @@
 
 #include <QtCore/QEvent>
 
-#include <QtGui/QApplication>
-#include <QtGui/QCompleter>
+#include <QtWidgets/QApplication>
+#include <QtWidgets/QCompleter>
 #include <QtGui/QFocusEvent>
-#include <QtGui/QHBoxLayout>
-#include <QtGui/QLabel>
-#include <QtGui/QLineEdit>
+#include <QtWidgets/QHBoxLayout>
+#include <QtWidgets/QLabel>
+#include <QtWidgets/QLineEdit>
 #include <QtGui/QPainter>
-#include <QtGui/QStyle>
-#include <QtGui/QStyleOptionFrameV2>
-#include <QtGui/QMessageBox>
+#include <QtWidgets/QStyle>
+#include <QtWidgets/QStyleOptionFrameV2>
+#include <QtWidgets/QMessageBox>
+#include <QDrag>
+#include <QWidget>
+#include <QMimeData>
 
 #include <QtCore/QDebug>
 

--- a/src/urllineedit.h
+++ b/src/urllineedit.h
@@ -43,8 +43,8 @@
 
 #include <QtCore/QUrl>
 #include <QLabel>
-#include <QtGui/QWidget>
-#include <QtGui/QStyleOptionFrame>
+#include <QWidget>
+#include <QStyleOptionFrame>
 #include "exlineedit.h"
 
 class WebView;

--- a/src/viewsource.h
+++ b/src/viewsource.h
@@ -5,6 +5,7 @@
 #define VIEWSOURCE_H
 
 #include <QMainWindow>
+#include <QTextEdit>
 #include <QSyntaxHighlighter>
 
 class HtmlHighlighter : public QSyntaxHighlighter

--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -49,13 +49,13 @@
 #include "autocomplete.h"
 
 #include <QtGui/QClipboard>
-#include <QtGui/QMenu>
-#include <QtGui/QMessageBox>
+#include <QtWidgets/QMenu>
+#include <QtWidgets/QMessageBox>
 #include <QtGui/QMouseEvent>
 #include <QProgressDialog>
 #include <QFileDialog>
 #include <QtNetwork>
-#include <QtWebKit/QWebHitTestResult>
+#include <QtWebKitWidgets/QWebHitTestResult>
 #include <qdesktopservices.h>
 #include <QtUiTools/QUiLoader>
 #include <QRegExp>

--- a/src/webpage.h
+++ b/src/webpage.h
@@ -47,7 +47,7 @@ class QFtp;
 class QProgressDialog;
 class QUrlInfo;
 
-#include <QtWebKit/QWebView>
+#include <QtWebKitWidgets/QWebView>
 
 QT_BEGIN_NAMESPACE
 class QAuthenticator;

--- a/src/webview.cpp
+++ b/src/webview.cpp
@@ -50,8 +50,8 @@
 #include "commands.h"
 
 #include <QtGui/QClipboard>
-#include <QtGui/QMenu>
-#include <QtGui/QMessageBox>
+#include <QtWidgets/QMenu>
+#include <QtWidgets/QMessageBox>
 #include <QtGui/QMouseEvent>
 #include <QProgressDialog>
 #include <QFileDialog>
@@ -60,6 +60,7 @@
 
 #include <QtCore/QDebug>
 #include <QtCore/QBuffer>
+#include <QFtp>
 
 
 WebView::WebView(QWidget* parent)   
@@ -248,7 +249,7 @@ void WebView::copyMailtoAddress()
     if (!m_hitResult.isNull() && !m_hitResult.linkUrl().isEmpty())
     {
         if (m_hitResult.linkUrl().scheme() == "mailto")
-            QApplication::clipboard()->setText( m_hitResult.linkUrl().encodedPath() );
+            QApplication::clipboard()->setText( m_hitResult.linkUrl().toEncoded());//.encodedPath() );
         else
         {
             if (!m_hitResult.linkUrl().scheme().isEmpty())
@@ -331,7 +332,7 @@ void WebView::applyEncoding()
 
         QString html = mainframe->toHtml();
 
-        QTextCodec *codec = QTextCodec::codecForName( enc.toAscii() );
+        QTextCodec *codec = QTextCodec::codecForName( enc.toLatin1() );
         if (!codec)
             return;
 
@@ -342,14 +343,14 @@ void WebView::applyEncoding()
         m_encoding_in_progress = true;
         m_current_encoding = enc;
         m_current_encoding_url = url();
-        QString output = decoder->toUnicode(html.toAscii());
+        QString output = decoder->toUnicode(html.toLatin1());
         mainframe->setHtml(output, mainframe->url());
 
         QList<QWebFrame *> children = mainframe->childFrames();
         foreach(QWebFrame *frame, children)
         {
             html = frame->toHtml();
-            output = decoder->toUnicode(html.toAscii());
+            output = decoder->toUnicode(html.toLatin1());
             frame->setHtml(output, frame->url());
         }
         m_encoding_in_progress = false;

--- a/src/webview.h
+++ b/src/webview.h
@@ -48,8 +48,8 @@ class QProgressDialog;
 class QUrlInfo;
 
 #include <QDateTime>
-#include <QtWebKit/QWebView>
-#include <QtWebKit/QWebHitTestResult>
+#include <QtWebKitWidgets/QWebView>
+#include <QtWebKitWidgets/QWebHitTestResult>
 
 class WebPage;
 


### PR DESCRIPTION
Hi magist3r,

I'm not sure when or if I'll work on this more, so I thought I better submit a pull request.

I haven't tested it built statically yet.  But I don't know when I'll get back to working on this project.  Hope this commit helps!

http://qt-project.org/wiki/Transition_from_Qt_4.x_to_Qt5

I fixed the headers by running this perl script from the source folder directory of QtWeb:

```
~/Qt5.2.1/5.2.1/Src/qtbase/bin/fixqt4headers.pl --qtdir ~/Qt5.2.1/5.2.1/Src/qtbase
```

The first dozen or so I did by hand.

Since QtFtp and QtHttp are now add-on plugins instead of standard elements I built those:

http://qt-project.org/forums/viewthread/24466/#121595

Most of the changes were pretty straightforward.  The differences in the CookieJar and History class with their use of `reset()` on their `QAbstractItemModel`s could use a second set of eyes, because they recommend wrapping the changes with `beginResetModel()` and `endResetModel()`.  I did it over a few minutes with really digging into the mechanics of those classes.

http://qt-project.org/doc/qt-5/qabstractitemmodel-compat.html#reset

Also the standardPaths changed to a `QStringList`, and for now I just put `.first()`.  Later error checking could be added in the bizarre case that an OS doesn't have any standardPaths available.

There are still a number of warnings, mostly

```
-Woverloaded-virtual
-Wunused-parameter
-Wsometimes-uninitialized
-Wreorder
-Wreorder
-Wsign-compare
```

and one

```
-Wcomment
```

Below are the screenshots of all the warnings (83 of them) thrown by a release build after a build clean.

![image](https://cloud.githubusercontent.com/assets/2342284/2825833/c3c34b54-cf5b-11e3-8ad0-a5a62beae2e7.png)

![image](https://cloud.githubusercontent.com/assets/2342284/2825834/dd4657d8-cf5b-11e3-8344-b7b4ca9a9b02.png)
